### PR TITLE
test: improve test coverage from 92% to 99%

### DIFF
--- a/test/providers/aws-parameter-store.provider.spec.ts
+++ b/test/providers/aws-parameter-store.provider.spec.ts
@@ -170,6 +170,28 @@ describe('AwsParameterStoreProvider', () => {
             await expect(provider.resolveSecret(paramRef)).rejects.toThrow('Parameter not found: /missing-para');
         });
 
+        it('should warn and exclude parameters with no value in a path lookup', async () => {
+            const pathRef = '/my-app/dev/*';
+
+            const mockResponse: GetParametersByPathCommandOutput = {
+                Parameters: [
+                    {Name: '/my-app/dev/key1', Type: 'String', Value: 'value1'},
+                    {Name: '/my-app/dev/key2', Type: 'String', Value: undefined},
+                    {Name: '/my-app/dev/key3', Type: 'String', Value: 'value3'}
+                ],
+                $metadata: {}
+            };
+
+            // @ts-expect-error: `never` type is inferred, which leads to type mismatch errors.
+            mockClient.send.mockResolvedValue(mockResponse);
+
+            const warnSpy = jest.spyOn((provider as any).logger, 'warn');
+            const result = await provider.resolveSecret(pathRef);
+
+            expect(warnSpy).toHaveBeenCalledWith('Parameter /my-app/dev/key2 has no value');
+            expect(result).toEqual(['value1', 'value3']);
+        });
+
         it('should throw an error if parameter access fails', async () => {
             const paramRef = '/access-denied-param';
 

--- a/test/services/secrets-loader.service.spec.ts
+++ b/test/services/secrets-loader.service.spec.ts
@@ -273,6 +273,127 @@ describe('SecretsLoaderService - createSecretProvider', () => {
     });
 });
 
+describe('SecretsLoaderService - coverage gaps', () => {
+    let service: SecretsLoaderService;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [SecretsLoaderService]
+        }).compile();
+
+        service = module.get<SecretsLoaderService>(SecretsLoaderService);
+
+        (fs.existsSync as jest.Mock).mockReturnValue(false);
+        (fs.readFileSync as jest.Mock).mockReturnValue('');
+    });
+
+    describe('loadConfigFiles', () => {
+        it('should warn and return empty config when files array is empty', async () => {
+            const warnSpy = jest.spyOn((service as any).logger, 'warn');
+
+            const result = await service.load({root: '/fake', files: []});
+
+            expect(result.get('anything')).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledWith('No configuration files specified');
+        });
+
+        it('should log an error and skip a file with invalid YAML', async () => {
+            (fs.existsSync as jest.Mock).mockReturnValue(true);
+            (fs.readFileSync as jest.Mock).mockReturnValue(': invalid: yaml: {[unclosed');
+
+            const errorSpy = jest.spyOn((service as any).logger, 'error');
+
+            await service.load({root: '/fake', files: ['bad.yaml']});
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to load config from')
+            );
+        });
+
+        it('should log an error and skip a file with invalid JSON', async () => {
+            (fs.existsSync as jest.Mock).mockReturnValue(true);
+            (fs.readFileSync as jest.Mock).mockReturnValue('{invalid json');
+
+            const errorSpy = jest.spyOn((service as any).logger, 'error');
+
+            await service.load({root: '/fake', files: ['bad.json'], fileType: 'json'});
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to load config from')
+            );
+        });
+    });
+
+    describe('loadProvider', () => {
+        it('should auto-detect provider type from client constructor name when no provider string is given', async () => {
+            const client = new SSMClient({});
+
+            const provider = await service.loadProvider({files: [], client});
+
+            expect(provider).toBeInstanceOf(AwsParameterStoreProvider);
+        });
+    });
+
+    describe('resolveBaseDirectory', () => {
+        it('should log a debug message and use default config directory when root is not specified', async () => {
+            const debugSpy = jest.spyOn((service as any).logger, 'debug');
+
+            await service.load({files: ['config.yaml']});
+
+            expect(debugSpy).toHaveBeenCalledWith(
+                expect.stringMatching(/No base directory specified, using:.*config/)
+            );
+        });
+
+        it('should resolve ./-relative paths from the current working directory', async () => {
+            const resolveBaseDirectorySpy = jest.spyOn(service as any, 'resolveBaseDirectory');
+
+            await service.load({root: './myconfig', files: ['app.yaml']});
+
+            expect(resolveBaseDirectorySpy.mock.results[0].value).toBe(
+                path.resolve(process.cwd(), './myconfig')
+            );
+        });
+
+        it('should resolve ../-relative paths from the current working directory', async () => {
+            const resolveBaseDirectorySpy = jest.spyOn(service as any, 'resolveBaseDirectory');
+
+            await service.load({root: '../myconfig', files: ['app.yaml']});
+
+            expect(resolveBaseDirectorySpy.mock.results[0].value).toBe(
+                path.resolve(process.cwd(), '../myconfig')
+            );
+        });
+    });
+
+    describe('resolveSecrets', () => {
+        it('should log an error and preserve the original value when the provider throws during resolution', async () => {
+            (fs.existsSync as jest.Mock).mockReturnValue(true);
+            (fs.readFileSync as jest.Mock).mockReturnValue('db:\n  password: /secrets/db-password');
+
+            const failingProvider: SecretsProvider = {
+                isSecretReference: jest.fn().mockReturnValue(true),
+                resolveSecret: jest.fn().mockRejectedValue(new Error('Access denied'))
+            };
+            const errorSpy = jest.spyOn((service as any).logger, 'error');
+
+            const result = await service.load({
+                root: '/fake',
+                files: ['config.yaml'],
+                provider: failingProvider
+            });
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to load secret [db.password]: Access denied')
+            );
+            // Value is preserved as the original reference since resolution failed
+            expect(result.get('db.password')).toEqual('/secrets/db-password');
+        });
+    });
+});
+
 describe('SecretsLoaderService - createSecretProviderViaClient', () => {
     let service: SecretsLoaderService;
 


### PR DESCRIPTION
## Summary

- Adds 9 new tests covering previously untested paths in `SecretsLoaderService` and `AwsParameterStoreProvider`
- Statement coverage: 92% → 99%
- Branch coverage: 80% → 92%
- All providers now at 100% coverage

## What's covered

- Empty `files` array returns empty config with a warning
- Malformed YAML and JSON files are skipped with an error log
- Provider auto-detection via `client.constructor.name` when no provider string is given
- Default config directory is logged when `root` is not specified
- CWD-relative paths (`./` and `../`) resolve correctly
- Secret resolution errors are logged and the original value is preserved
- AWS Parameter Store path lookups warn and exclude parameters with no value

## Test plan

- [x] `npm test` — 63 tests passing (up from 54)

🤖 Generated with [Claude Code](https://claude.com/claude-code)