### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@floracodex/nestjs-secrets",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@floracodex/nestjs-secrets",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@floracodex/nestjs-secrets",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A cloud-agnostic configuration loader for NestJS with secret management integration",
   "keywords": [
     "nestjs",


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1 for patch release

## What's changed since 1.0.0
- **chore(deps):** Updated all dependencies, resolving 16 dependabot PRs including security fixes for lodash (prototype pollution) and fast-xml-parser (entity expansion)
- **chore:** Upgraded eslint to v10, @types/node to v25, adopted FloraCodex backend lint config with @stylistic plugin
- **test:** Improved test coverage from 92% to 99% (54 → 63 tests)

## Test plan
- [x] `npm test` — 63/63 tests pass
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)