### PR TITLE
chore(ci): switch to OIDC trusted publishing and Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [ 18.x, 20.x, 22.x ]
+                node-version: [ 20.x, 22.x, 24.x ]
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
 
             -   name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v4
+                uses: actions/setup-node@v6
                 with:
                     node-version: ${{ matrix.node-version }}
                     cache: 'npm'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,30 +7,33 @@ on:
     release:
         types: [published]
 
+permissions:
+    contents: read
+    id-token: write
+
 jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20.x
+                  node-version: 24.x
             - run: npm ci
+            - run: npm run build
             - run: npm test
 
     publish-npm:
         needs: build
         runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            id-token: write
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20.x
+                  node-version: 24.x
                   registry-url: https://registry.npmjs.org/
             - run: npm ci
+            - run: npm run build
             - run: npm publish --provenance --access public
               env:
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+                  NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary
- Switch npm publish workflow to OIDC trusted publishing, removing the need for an `NPM_TOKEN` secret
- Standardize all CI jobs on Node 24.x (npm 11.5+ required for OIDC support)
- Rename `npm-tests.yml` → `ci.yml` and update test matrix to `[20.x, 22.x, 24.x]`
- Bump `actions/checkout` and `actions/setup-node` to v6

## Test plan
- [ ] CI passes on this PR with the renamed workflow
- [ ] Verify next release publishes successfully via OIDC (no NPM_TOKEN needed)
- [ ] Remove `NPM_TOKEN` secret from repo settings after confirming OIDC works

🤖 Generated with [Claude Code](https://claude.com/claude-code)