### PR TITLE
chore: bump direct deps to current minor/patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,24 +14,24 @@
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.803.0",
-        "@aws-sdk/client-ssm": "^3.804.0",
+        "@aws-sdk/client-secrets-manager": "^3.1041.0",
+        "@aws-sdk/client-ssm": "^3.1041.0",
         "@azure/identity": "^4.9.1",
         "@azure/keyvault-secrets": "^4.9.0",
         "@floracodex/eslint-config": "^1.0.1",
-        "@google-cloud/secret-manager": "^6.0.1",
-        "@nestjs/cli": "^11.0.7",
+        "@google-cloud/secret-manager": "^6.1.2",
+        "@nestjs/cli": "^11.0.21",
         "@nestjs/testing": "^11.1.0",
         "@types/jest": "^29.5.14",
         "@types/js-yaml": "^4.0.9",
         "@types/lodash": "^4.17.16",
         "@types/node": "^25.6.0",
-        "eslint": "^10.2.0",
+        "eslint": "^10.3.0",
         "jest": "^29.7.0",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.3.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.3"
       },
       "peerDependencies": {
         "@aws-sdk/client-secrets-manager": "^3.799.0",
@@ -445,22 +445,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -559,20 +543,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics-cli/node_modules/restore-cursor": {
@@ -4164,22 +4134,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nestjs/schematics/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -4278,20 +4232,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nestjs/schematics/node_modules/restore-cursor": {
@@ -6997,22 +6937,6 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/chownr": {
       "version": "3.0.0",
@@ -12755,20 +12679,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -61,24 +61,24 @@
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.803.0",
-    "@aws-sdk/client-ssm": "^3.804.0",
+    "@aws-sdk/client-secrets-manager": "^3.1041.0",
+    "@aws-sdk/client-ssm": "^3.1041.0",
     "@azure/identity": "^4.9.1",
     "@azure/keyvault-secrets": "^4.9.0",
     "@floracodex/eslint-config": "^1.0.1",
-    "@google-cloud/secret-manager": "^6.0.1",
-    "@nestjs/cli": "^11.0.7",
+    "@google-cloud/secret-manager": "^6.1.2",
+    "@nestjs/cli": "^11.0.21",
     "@nestjs/testing": "^11.1.0",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.16",
     "@types/node": "^25.6.0",
-    "eslint": "^10.2.0",
+    "eslint": "^10.3.0",
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.799.0",


### PR DESCRIPTION
## Summary

Roll forward all non-major dep upgrades. Closes the work of open dependabot PRs #131, #132, #133, #134.

| Package | From | To |
|---|---|---|
| @aws-sdk/client-secrets-manager | ^3.803.0 | ^3.1041.0 |
| @aws-sdk/client-ssm | ^3.804.0 | ^3.1041.0 |
| @google-cloud/secret-manager | ^6.0.1 | ^6.1.2 |
| @nestjs/cli | ^11.0.7 | ^11.0.21 |
| eslint | ^10.2.0 | ^10.3.0 |
| typescript | ^5.8.3 | ^5.9.3 |

## What's not bumped

- **jest 29 → 30, @types/jest 29 → 30** — major version, deferred to a separate PR with proper test verification.
- **typescript 5.x → 6.0** — major. Some toolchain coverage isn't fully there yet (typescript-eslint, ts-jest, @nestjs/cli all need to be on TS 6-compatible versions). Defer until the ecosystem catches up.

## Base

This branches off #135 (eslint-config adoption); merge that first.

## Test plan

- [x] `npm install` clean; `npm outdated` shows only the deferred majors
- [x] `npm run lint` clean (with `--max-warnings 0`)
- [x] `npm run build` — `nest build` succeeds
- [x] `npm test` — 63/63 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)