### PR TITLE
chore: bump @floracodex/eslint-config to ^1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@aws-sdk/client-ssm": "^3.1041.0",
         "@azure/identity": "^4.9.1",
         "@azure/keyvault-secrets": "^4.9.0",
-        "@floracodex/eslint-config": "^1.0.1",
+        "@floracodex/eslint-config": "^1.1.0",
         "@google-cloud/secret-manager": "^6.1.2",
         "@nestjs/cli": "^11.0.21",
         "@nestjs/testing": "^11.1.0",
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/@floracodex/eslint-config": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@floracodex/eslint-config/-/eslint-config-1.0.1.tgz",
-      "integrity": "sha512-3yUdjj81ZdiQ2J8JdRsr+T1Vys4XHTCyGZLeymr5BQ+fKYyUVAcB4elH2Fh7VihaUN91yJCetanGg9ViWtWuDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floracodex/eslint-config/-/eslint-config-1.1.0.tgz",
+      "integrity": "sha512-Bniq4gO9B9H3ZLcPy8KeO5yPlhEwdgUZ76zeb4TFCKc/cCknypVKRCW06REeK0v0jAEsmhonffoSyLK7cHgnVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@aws-sdk/client-ssm": "^3.1041.0",
     "@azure/identity": "^4.9.1",
     "@azure/keyvault-secrets": "^4.9.0",
-    "@floracodex/eslint-config": "^1.0.1",
+    "@floracodex/eslint-config": "^1.1.0",
     "@google-cloud/secret-manager": "^6.1.2",
     "@nestjs/cli": "^11.0.21",
     "@nestjs/testing": "^11.1.0",


### PR DESCRIPTION
v1.1.0 extends the \`**/*.spec.ts\` override across all app presets and adds \`@typescript-eslint/require-await\` to the shared rule set. No local change needed in this repo (the existing \`secrets-loader.service.ts\` override stays); the bump just keeps us current with the family.

## Test plan

- [x] \`npm run lint\` — clean (\`--max-warnings 0\`)
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 63/63 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)