### PR TITLE
chore: prep tsconfig for TypeScript 6

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
   "exclude": [
     "node_modules",
     "test",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary
- Add explicit \`rootDir: \"./src\"\` to \`tsconfig.build.json\` (TS6 no longer infers it when \`exclude\` covers \`test\`/\`example\`/\`**/*spec.ts\` — emits TS5011).
- Drop unused \`baseUrl: \"./\"\` from \`tsconfig.json\` (deprecated in TS6, emits TS5101). No \`paths\` mapping exists and all imports are bare or relative.

Unblocks #143 (dependabot \`typescript\` 5.9 → 6.0.3) once rebased.

## Test plan
- [x] \`npm run build\` (TS 5.9) green
- [x] \`npm run lint\` green
- [x] \`npm test\` — 63 passed
- [x] \`npx -p typescript@6.0.3 -- tsc --noEmit -p tsconfig.build.json\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)