### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@floracodex/nestjs-secrets",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@floracodex/nestjs-secrets",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@floracodex/nestjs-secrets",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "workspaces": [
     "example"
   ],


### PR DESCRIPTION
## Summary
Bumps \`package.json\` from 1.0.2 → 1.0.3 ahead of cutting the v1.0.3 release. Rolls up the 12 chore PRs merged since v1.0.2 (tooling, lint config, type-def updates, transitive security bumps, npm workspaces, jest 30, tsconfig prep for TS6). No source changes; published \`dist/\` is effectively unchanged.

## Test plan
- [x] \`npm run lint\` green
- [x] \`npm run build\` green
- [x] \`npm test\` — 63 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)